### PR TITLE
enable optional username@dbname syntax if the container supports it

### DIFF
--- a/src/main/scala/io/chrisdavenport/testcontainersspecs2/PostgresMultiple.scala
+++ b/src/main/scala/io/chrisdavenport/testcontainersspecs2/PostgresMultiple.scala
@@ -14,7 +14,7 @@ trait UsesPostgresqlMultipleDatabases { self: { def container: Container } =>
     name = "christopherdavenport/postgres-multi-db:10.3",
     exposedPort = 5432,
     dbName = dbName,
-    dbUserName = dbUserName,
+    dbLoginName = dbUserName,
     dbPassword = dbPassword
   )
 
@@ -27,11 +27,11 @@ trait UsesPostgresqlMultipleDatabases { self: { def container: Container } =>
 }
 
 final class PostgresqlMultipleDatabases(
-  name: String,
-  exposedPort: Int,
-  dbName: String,
-  dbUserName: String,
-  dbPassword: String
+     name: String,
+     exposedPort: Int,
+     dbName: String,
+     dbLoginName: String,
+     dbPassword: String
 ){
 
   lazy val container: GenericContainer = GenericContainer(
@@ -39,7 +39,7 @@ final class PostgresqlMultipleDatabases(
     exposedPorts = Seq(exposedPort),
     env = Map(
       "REPO" -> "https://github.com/mrts/docker-postgresql-multiple-databases",
-      "POSTGRES_USER" -> dbUserName,
+      "POSTGRES_USER" -> dbLoginName,
       "POSTGRES_PASSWORD" ->  dbPassword,
       "POSTGRES_MULTIPLE_DATABASES"  -> dbName
     ),
@@ -51,5 +51,6 @@ final class PostgresqlMultipleDatabases(
 
   lazy val ipAddress = container.containerIpAddress
   lazy val mappedPort = container.mappedPort(exposedPort)
-  lazy val jdbcUrl: String = s"jdbc:postgresql://$ipAddress:$mappedPort/$dbName"
+  val subIx = dbName.indexOf('@')
+  lazy val jdbcUrl: String = s"jdbc:postgresql://$ipAddress:$mappedPort/${if (-1 == subIx) dbName else dbName.substring(subIx+1)}"
 }

--- a/src/test/scala/io/chrisdavenport/testcontainersspecs2/MigrationsSpec.scala
+++ b/src/test/scala/io/chrisdavenport/testcontainersspecs2/MigrationsSpec.scala
@@ -11,14 +11,14 @@ class MigrationsSpec extends Specification with ForAllTestContainer {
     name = "christopherdavenport/postgres-multi-db:10.3",
     exposedPort = 5432,
     dbName = dbName,
-    dbUserName = dbUserName,
+    dbLoginName = dbLogin,
     dbPassword = dbPassword
   )
   // IMPORTANT: MUST BE LAZY VAL
   override lazy val container = multiple.container
 
   lazy val driverName = "org.postgresql.Driver"
-  lazy val dbUserName = "user"
+  lazy val dbLogin = "user"
   lazy val dbPassword = "password"
   lazy val dbName = "db"
   lazy val jdbcUrl = multiple.jdbcUrl
@@ -26,7 +26,7 @@ class MigrationsSpec extends Specification with ForAllTestContainer {
   "Migrations should run Correctly" in {
     IO {
       lazy val flyway = new Flyway
-      flyway.setDataSource(jdbcUrl, dbUserName, dbPassword)
+      flyway.setDataSource(jdbcUrl, dbLogin, dbPassword)
       flyway.migrate()
       ()
     }.attempt

--- a/src/test/scala/io/chrisdavenport/testcontainersspecs2/QueriesSpec.scala
+++ b/src/test/scala/io/chrisdavenport/testcontainersspecs2/QueriesSpec.scala
@@ -20,7 +20,7 @@ trait QueriesSpec[F[_]] extends Specification with Checker[F] with ForAllTestCon
     name = "christopherdavenport/postgres-multi-db:10.3",
     exposedPort = 5432,
     dbName = dbName,
-    dbUserName = dbUserName,
+    dbLoginName = dbLogin,
     dbPassword = dbPassword
   )
 
@@ -28,7 +28,7 @@ trait QueriesSpec[F[_]] extends Specification with Checker[F] with ForAllTestCon
   override lazy val container = multiple.container
 
   lazy val driverName = "org.postgresql.Driver"
-  lazy val dbUserName = "user"
+  lazy val dbLogin = "user"
   lazy val dbPassword = "password"
   lazy val dbName = "db"
 
@@ -36,7 +36,7 @@ trait QueriesSpec[F[_]] extends Specification with Checker[F] with ForAllTestCon
   lazy val transactor = Transactor.fromDriverManager[F](
     driverName,
     multiple.jdbcUrl,
-    dbUserName,
+    dbLogin,
     dbPassword
   )
 
@@ -47,7 +47,7 @@ trait QueriesSpec[F[_]] extends Specification with Checker[F] with ForAllTestCon
   // In this case we make sure migrations have run before we check the sql statements.
   override def afterStart(): Unit = {
     lazy val flyway = new Flyway
-    flyway.setDataSource(multiple.jdbcUrl, dbUserName, dbPassword)
+    flyway.setDataSource(multiple.jdbcUrl, dbLogin, dbPassword)
     flyway.migrate()
     ()
   }


### PR DESCRIPTION
an enhanced docker container may allow using syntax like "username@dbname" to set up user `username` on the newly created `dbname` at the time of creation.  (The default is to have identical user and db name on creation.)  This PR allows testcontainers to take advantage of the enhanced feature, maintaining backwards compatibility.