### PR TITLE
expose ipAddress and port

### DIFF
--- a/src/main/scala/io/chrisdavenport/testcontainersspecs2/UsesPostgreSQLMultipleDatabases.scala
+++ b/src/main/scala/io/chrisdavenport/testcontainersspecs2/UsesPostgreSQLMultipleDatabases.scala
@@ -27,6 +27,8 @@ trait UsesPostgreSQLMultipleDatabases {
   lazy val dbPassword: String = "password"
   lazy val dbName: String = "db"
   lazy val jdbcUrl: String = multiple.jdbcUrl
+  lazy val ipAddress: String = multiple.ipAddress
+  lazy val port: String = multiple.mappedPort
 
   final class PostgreSQLMultipleDatabases(
       name: String,

--- a/src/main/scala/io/chrisdavenport/testcontainersspecs2/UsesPostgreSQLMultipleDatabases.scala
+++ b/src/main/scala/io/chrisdavenport/testcontainersspecs2/UsesPostgreSQLMultipleDatabases.scala
@@ -28,7 +28,7 @@ trait UsesPostgreSQLMultipleDatabases {
   lazy val dbName: String = "db"
   lazy val jdbcUrl: String = multiple.jdbcUrl
   lazy val ipAddress: String = multiple.ipAddress
-  lazy val port: String = multiple.mappedPort
+  lazy val port: Int = multiple.mappedPort
 
   final class PostgreSQLMultipleDatabases(
       name: String,


### PR DESCRIPTION
Id like to use the library in an existing app that takes `ipAddress`, `port` as config params rather than jdbc url, so exposing them to clients of the library