### PR TITLE
Bump scalatest version to v0.38.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val catsEffectV = "2.1.3"    //https://github.com/typelevel/cats-effect/releases
 val doobieV = "0.9.0"        //https://github.com/tpolecat/doobie/releases
 val flyWayV = "6.4.4"           //https://github.com/flyway/flyway/releases
 val specs2V = "4.10.0"           //https://github.com/etorreborre/specs2/releases
-val testcontainersSV = "0.37.0" //https://github.com/testcontainers/testcontainers-scala/releases
+val testcontainersSV = "0.38.4" //https://github.com/testcontainers/testcontainers-scala/releases
 
 lazy val contributors = Seq(
   "aeons"                -> "Bjørn Madsen",


### PR DESCRIPTION
Upstream changes to docker broke  `testcontainers` all the way down for MacOS. This library needs to update to reflect this change. 