### PR TITLE
Upgrade testcontainers-scala to 0.39.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Coursier
@@ -46,7 +46,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v2
-  #     - uses: olafurpg/setup-scala@v5
+  #     - uses: olafurpg/setup-scala@v10
   #     - name: Cache Coursier
   #       uses: actions/cache@v1
   #       with:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val catsEffectV = "2.1.3"    //https://github.com/typelevel/cats-effect/releases
 val doobieV = "0.9.0"        //https://github.com/tpolecat/doobie/releases
 val flyWayV = "6.4.4"           //https://github.com/flyway/flyway/releases
 val specs2V = "4.10.5"           //https://github.com/etorreborre/specs2/releases
-val testcontainersSV = "0.38.4" //https://github.com/testcontainers/testcontainers-scala/releases
+val testcontainersSV = "0.39.3" //https://github.com/testcontainers/testcontainers-scala/releases
 
 lazy val contributors = Seq(
   "aeons"                -> "Bjørn Madsen",


### PR DESCRIPTION
Updates the testcontainers-java dependency to 1.15.2 in order to resolve issues similar to https://github.com/testcontainers/testcontainers-java/issues/3574